### PR TITLE
Added check to see if event times are in the past.

### DIFF
--- a/app/mod_api/views.py
+++ b/app/mod_api/views.py
@@ -143,7 +143,6 @@ def edit_event(id):
 	except ValidationError as e:
 		return gen_error_response("Request was malformatted.")
 	except Exception as e:
-		raise e
 		return gen_failure_response(str(e))
 
 	if updated_event is None:

--- a/test/test.py
+++ b/test/test.py
@@ -221,7 +221,6 @@ def test_add_event_extra_field():
 
 def test_add_event_in_past():
 	# Tests events with endtimes that have already happened.
-
 	old_event = deepcopy(base_event)
 
 	days_ago = 7


### PR DESCRIPTION
If the end datetime of an instance has already occurred, an error is thrown.
I implemented this with a grace period, currently set to one day. So users can add events that have finished sometime in the last 24 hours.
I also fixed a bug that arose when trying to edit the datetimes of events.