### PR TITLE
Fixed small display bug with deleting events.

### DIFF
--- a/app/static/js/displayEvent.js
+++ b/app/static/js/displayEvent.js
@@ -1,5 +1,7 @@
 // TODO: add all of Reilly's code pertaining to the large event layout here
 
+var selected_event = null;
+
 // Shows large event view when search result is clicked
 var updateEventView = function() {
 		$(".smallSearchResult").click( function(){
@@ -10,6 +12,7 @@ var updateEventView = function() {
 		    	// populate and display event view.
 			$(".event-view").hide();
 			var eventNum = getNum($(this).attr("id"), "smallSearchResult") - 1;
+			selected_event = event_data[eventNum];
 			populateEventViewPanel(eventNum);
 			$("#event-view").show();
 		});
@@ -27,4 +30,17 @@ function populateEventViewPanel(num) {
 		"Time: " + event_data[num]["instances"][0].start_datetime;
 	document.getElementById("eventDescription").innerHTML = 
 		"Description: " + event_data[num].description;
+}
+
+// Get event id of currently selected event.
+function getSelectedEvent() {
+	if (selected_event == null) {
+		return null;
+	}
+	return selected_event;
+}
+
+// Hide event view panel.
+function hideEventViewPanel() {
+	$(".event-view").hide();
 }

--- a/app/static/js/myevent.js
+++ b/app/static/js/myevent.js
@@ -47,6 +47,11 @@ var changeMyEvents = function() {
 			
 			var callback = function() {
 				loadEvents();
+				// If the event is selected, hide the view after it is deleted.
+				var selected_event = getSelectedEvent();
+				if (selected_event !== null && selected_event._id == eventId) {
+					hideEventViewPanel();
+				}
 			}
 			$.ajax({
 				url: base_url + '/api/event/delete/' + eventId,


### PR DESCRIPTION
When an event that was selected was deleted, the event view was not hidden, so the data for a now deleted event was being shown. I resolved this.