### PR TITLE
Trending fix.

### DIFF
--- a/app/mod_api/controllers.py
+++ b/app/mod_api/controllers.py
@@ -106,8 +106,8 @@ def get_trending_events(user = None):
 	start_datetime = datetime.now() - timedelta(minutes = 5)
 	end_datetime = datetime.now() + timedelta(days = 7)
 	
-	trending_events = EventEntry.objects(instances__match={'end_datetime__gte': start_datetime, 
-		'end_datetime__lte': end_datetime},
+	trending_events = EventEntry.objects(instances__match={'start_datetime__lte': end_datetime, 
+		'end_datetime__gte': start_datetime},
 		visibility__lte = get_max_visibility(user))
 	trending_events = trending_events.order_by('-favorites').limit(trending_size)
 	return trending_events

--- a/test/test.py
+++ b/test/test.py
@@ -570,6 +570,8 @@ def generate_event(i):
 	event["instances"][0]["end_datetime"] = str(now + timedelta(hours=1))
 	return event
 
+trending_size = 15
+
 def test_trending_event_valid_no_auth():
 	def test(new_events):
 		r = make_get_trending_request()
@@ -579,7 +581,7 @@ def test_trending_event_valid_no_auth():
 		expected_trending = list(filter(lambda x: x["visibility"] == 0, expected_trending))
 		for i in range(len(r['data'])):
 			assert compare_events(expected_trending[i], r['data'][i])
-	make_test_multi(test, 20, generate_event)
+	make_test_multi(test, trending_size + 5, generate_event)
 
 def test_trending_event_valid():
 	def test(new_events):
@@ -588,7 +590,67 @@ def test_trending_event_valid():
 		expected_trending = sorted(new_events, key=lambda x: x["favorites"], reverse=True)
 		for i in range(len(r['data'])):
 			assert compare_events(expected_trending[i], r['data'][i])
-	make_test_multi(test, 20, generate_event)
+	make_test_multi(test, trending_size + 5, generate_event)
+
+# Make sure that all trending events occur sometime in the next week.
+def test_trending_event_date_range():
+	now = datetime.now().replace(second=0, microsecond=0)
+	d = timedelta(days=1)
+
+	# Each element in the array is instance data for an event.
+	# Each tuple in an element is an instance in the form of (start time, end time).
+	test_event_datetimes = [[(now - d, now)], 
+		[(now - 7 * d, now - d)], 
+		[(now - 7 * d, now - d), (now + d, now + 10 * d)],
+		[(now, now + d), (now, now + 2 * d)], 
+		[(now + 99 * d, now + 100 * d)], 
+		[(now - d, now - timedelta(minutes = 1))],
+		[(now - 10 * d, now - 9 * d), (now + 10 * d, now + 11 * d)]]
+	# Hardcoded inrange answers.
+	test_event_inrange = [True, False, True, True, False, True, False]
+	assert len(test_event_datetimes) == len(test_event_inrange)
+
+	def test_data(i):
+		trending_event = generate_event(i)
+		if i >= len(test_event_datetimes):
+			return trending_event
+		trending_event["instances"] = []
+		for start, end in test_event_datetimes[i]:
+			trending_event["instances"].append({
+				'location': 'trend city',
+				'start_datetime': str(start),
+				'end_datetime': str(end)
+				})		
+		return trending_event
+
+	# Is event in the correct date range to be eligible for 'trending'?
+	def in_range(event):
+		for instance in event["instances"]:
+			start_in_range = parse(instance["end_datetime"]) >= now - timedelta(minutes = 5)
+			end_in_range = parse(instance["start_datetime"]) <= now + timedelta(days = 7)
+			if start_in_range and end_in_range:
+				return True
+		return False
+
+	def test(new_events):
+		r = make_get_trending_request(generate_auth_token("jneus"))
+		
+		assert is_success(r)
+		events_in_range = filter(in_range, new_events)
+		expected_trending = sorted(events_in_range, key=lambda x: x["favorites"], reverse=True)
+		
+		for i in range(len(r['data'])):
+			assert compare_events(expected_trending[i], r['data'][i])
+		# As an extra sanity check, look at hardcoded answer key.
+		# This relies on the fact that test_data(i) has i favorites.
+		expected_events = set(filter(lambda x: test_event_inrange[x], range(len(test_event_inrange))))
+		
+		for i in range(len(r['data'])):
+			assert r['data'][i]['favorites'] in expected_events
+			expected_events.remove(r['data'][i]['favorites'])
+		assert len(expected_events) == 0
+
+	make_test_multi(test, len(test_event_datetimes), test_data)
 
 # Can't add two reports within a certain number of seconds of one another.
 def test_report_two_reports():
@@ -796,8 +858,8 @@ test_search_tag,
 test_search_tag_json,
 test_search_json_override,
 test_valid_feedback,
-test_invalid_feedback
-]
+test_invalid_feedback,
+test_trending_event_date_range]
 
 if __name__ == '__main__':
 	setup()

--- a/test/testing.md
+++ b/test/testing.md
@@ -21,6 +21,7 @@ To test LampPost, run the following from the main directory:
 ./test/test.sh (in one window)
 python3 test/test.py (in a second window)
 ```
+It is important you run test.sh first, as this starts up the local mongo instance.
 ## Adding Tests
 To add tests to ```tests.py```, simply create a function for each test, and add the function name(s) to the ```tests``` array found at the bottom of ```tests.py```. 
 


### PR DESCRIPTION
The trending API endpoint sets a range [now-5min, now+7days] and only considers events in that range.
The current code in develop has two issues: it doesn't determine whether or not an event is in range correctly, and, even if it did, it doesn't always work for events with more than once instance. This is because I couldn't figure out how to query for events where one particular instance matched a series of requirements, and instead could only ask for things like "events with AN end datetime >= ... and A start datetime <= ..." -- I couldn't guarantee that the start and end datetimes that matched these conditions belonged to the same instance.
Anyways, this PR fixes that. I've also added a test for this with a bunch of cases.